### PR TITLE
Jail items bug fix

### DIFF
--- a/client/prisonbreak.lua
+++ b/client/prisonbreak.lua
@@ -71,7 +71,9 @@ end)
 Citizen.CreateThread(function()
 	while true do
 		Citizen.Wait(7)
+        local src = source
 		local pos = GetEntityCoords(PlayerPedId(), true)
+        local Player = QBCore.Functions.GetPlayer(src)
         if #(pos - vector3(Config.Locations["middle"].coords.x, Config.Locations["middle"].coords.y, Config.Locations["middle"].coords.z)) > 200 and inJail then
 			inJail = false
             jailTime = 0
@@ -84,6 +86,7 @@ Citizen.CreateThread(function()
             ShopBlip = nil
             TriggerServerEvent("prison:server:SecurityLockdown")
             TriggerEvent('prison:client:PrisonBreakAlert')
+            Player.Functions.SetMetaData("jailitems", {})
             QBCore.Functions.Notify("You escaped... Get the hell out of here.!", "error")
 		end
 	end

--- a/server/main.lua
+++ b/server/main.lua
@@ -30,7 +30,6 @@ RegisterServerEvent('prison:server:GiveJailItems')
 AddEventHandler('prison:server:GiveJailItems', function()
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    Player.Functions.ClearInventory()
     Citizen.Wait(1000)
     for k, v in pairs(Player.PlayerData.metadata["jailitems"]) do
         Player.Functions.AddItem(v.name, v.amount, false, v.info)


### PR DESCRIPTION
Stop items from clearing on exit #22

When escaping jail you don't receive any of your items, however if jailed again and let out you receive all your old items again. Bit weird that the prison would return those so I made it wipe those items upon escaping jail.