### PR TITLE
Weapon in hand fix

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -139,6 +139,8 @@ RegisterNetEvent('prison:client:Leave', function()
 		RemoveBlip(ShopBlip)
 		ShopBlip = nil
 		QBCore.Functions.Notify(Lang:t("success.free_"))
+		local weaponOnHand = GetSelectedPedWeapon(PlayerPedId())
+		RemoveWeaponFromPed(PlayerPedId(), weaponOnHand)
 		DoScreenFadeOut(500)
 		while not IsScreenFadedOut() do
 			Wait(10)


### PR DESCRIPTION
When guards attack NPC prisoners they get a rifle and you can get them killed in one hit. This prevents the player from being released by serving prison time with a gun in hand.