### PR TITLE
fix(client/prisonbreak): coords table for phone alert

### DIFF
--- a/client/prisonbreak.lua
+++ b/client/prisonbreak.lua
@@ -103,7 +103,7 @@ end)
 
 RegisterNetEvent('prison:client:PrisonBreakAlert', function()
     local coords = vector3(Config.Locations["middle"].coords.x, Config.Locations["middle"].coords.y, Config.Locations["middle"].coords.z)
-    local alertData = {title = "New Call", coords = {coords.x, coords.y, coords.z}, description = "Prison outbreak"}
+    local alertData = {title = "New Call", coords = {x = coords.x, y = coords.y, z = coords.z}, description = "Prison outbreak"}
     TriggerEvent("qb-phone:client:addPoliceAlert", alertData)
     TriggerEvent('police:client:policeAlert', coords, "Prison outbreak")
 


### PR DESCRIPTION
**Describe Pull request**
Fixes the issue of the phone alert leading you to 0,0,0 instead of the actual position you need to be at for the alert

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
