### PR TITLE
fix(client/main): use config for ped coords

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -75,22 +75,25 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
 	end)
 
 	if DoesEntityExist(canteen_ped) or DoesEntityExist(freedom_ped) then return end
+
 	local pedModel = `s_m_m_armoured_01`
+
 	RequestModel(pedModel)
 	while not HasModelLoaded(pedModel) do
 		Wait(0)
 	end
-	canteen_ped = CreatePed(0, pedModel ,1786.19, 2557.77, 44.62, 186.04, false, true)
-	FreezeEntityPosition(canteen_ped, true)
-	SetEntityInvincible(canteen_ped, true)
-	SetBlockingOfNonTemporaryEvents(canteen_ped, true)
-	TaskStartScenarioInPlace(canteen_ped, 'WORLD_HUMAN_CLIPBOARD', 0, true)
 
-	freedom_ped = CreatePed(0, pedModel , 1836.37, 2585.33, 44.88, 78.67, false, true)
+	freedom_ped = CreatePed(0, pedModel, Config.Locations["freedom"].coords.x, Config.Locations["freedom"].coords.y, Config.Locations["freedom"].coords.z, Config.Locations["freedom"].coords.w, false, true)
 	FreezeEntityPosition(freedom_ped, true)
 	SetEntityInvincible(freedom_ped, true)
 	SetBlockingOfNonTemporaryEvents(freedom_ped, true)
 	TaskStartScenarioInPlace(freedom_ped, 'WORLD_HUMAN_CLIPBOARD', 0, true)
+
+	canteen_ped = CreatePed(0, pedModel, Config.Locations["shop"].coords.x, Config.Locations["shop"].coords.y, Config.Locations["shop"].coords.z, Config.Locations["shop"].coords.w, false, true)
+	FreezeEntityPosition(canteen_ped, true)
+	SetEntityInvincible(canteen_ped, true)
+	SetBlockingOfNonTemporaryEvents(canteen_ped, true)
+	TaskStartScenarioInPlace(canteen_ped, 'WORLD_HUMAN_CLIPBOARD', 0, true)
 
 	if not Config.UseTarget then return end
 
@@ -142,22 +145,25 @@ AddEventHandler('onResourceStart', function(resource)
 	end)
 
 	if DoesEntityExist(canteen_ped) or DoesEntityExist(freedom_ped) then return end
+
 	local pedModel = `s_m_m_armoured_01`
+
 	RequestModel(pedModel)
 	while not HasModelLoaded(pedModel) do
 		Wait(0)
 	end
-	canteen_ped = CreatePed(0, pedModel, 1786.19, 2557.77, 44.62, 186.04, false, true)
-	FreezeEntityPosition(canteen_ped, true)
-	SetEntityInvincible(canteen_ped, true)
-	SetBlockingOfNonTemporaryEvents(canteen_ped, true)
-	TaskStartScenarioInPlace(canteen_ped, 'WORLD_HUMAN_CLIPBOARD', 0, true)
 
-	freedom_ped = CreatePed(0, pedModel, 1836.37, 2585.33, 44.88, 78.67, false, true)
+	freedom_ped = CreatePed(0, pedModel, Config.Locations["freedom"].coords.x, Config.Locations["freedom"].coords.y, Config.Locations["freedom"].coords.z, Config.Locations["freedom"].coords.w, false, true)
 	FreezeEntityPosition(freedom_ped, true)
 	SetEntityInvincible(freedom_ped, true)
 	SetBlockingOfNonTemporaryEvents(freedom_ped, true)
 	TaskStartScenarioInPlace(freedom_ped, 'WORLD_HUMAN_CLIPBOARD', 0, true)
+
+	canteen_ped = CreatePed(0, pedModel, Config.Locations["shop"].coords.x, Config.Locations["shop"].coords.y, Config.Locations["shop"].coords.z, Config.Locations["shop"].coords.w, false, true)
+	FreezeEntityPosition(canteen_ped, true)
+	SetEntityInvincible(canteen_ped, true)
+	SetBlockingOfNonTemporaryEvents(canteen_ped, true)
+	TaskStartScenarioInPlace(canteen_ped, 'WORLD_HUMAN_CLIPBOARD', 0, true)
 
 	if not Config.UseTarget then return end
 

--- a/config.lua
+++ b/config.lua
@@ -33,19 +33,19 @@ Config.Locations = {
         }
     },
     ["freedom"] = {
-        coords = vector4(1836.37, 2585.33, 45.89, 272.96)
+        coords = vector4(1740.88, 2476.57, 44.85, 299.49)
     },
     ["outside"] = {
-        coords = vector4(1848.13, 2586.05, 45.67, 269.5)
+        coords = vector4(1848.13, 2586.05, 44.67, 269.5)
     },
     ["yard"] = {
-        coords = vector4(1765.67, 2565.91, 45.56, 1.5)
+        coords = vector4(1765.67, 2565.91, 44.56, 1.5)
     },
     ["middle"] = {
-        coords = vector4(1693.33, 2569.51, 45.55, 123.5)
+        coords = vector4(1693.33, 2569.51, 44.55, 123.5)
     },
     ["shop"] = {
-        coords = vector4(1786.19, 2557.77, 45.62, 0.5)
+        coords = vector4(1777.59, 2560.52, 44.62, 187.83)
     },
     spawns = {
         [1] = {


### PR DESCRIPTION
**Describe Pull request**
This fixes the issue of #75 not changing the coords of the peds whenever the config of it is changed

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
