### PR TITLE
Fix another exploit

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -205,6 +205,9 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
 end)
 
 RegisterNetEvent('prison:client:Enter', function(time)
+	local invokingResource = GetInvokingResource()
+	if invokingResource and invokingResource ~= 'qb-policejob' and invokingResource ~= 'qb-ambulancejob' and invokingResource ~= GetCurrentResourceName() then return end
+
 	QBCore.Functions.Notify( Lang:t("error.injail", {Time = time}), "error")
 
 	TriggerEvent("chatMessage", "SYSTEM", "warning", "Your property has been seized, you'll get everything back when your time is up..")

--- a/client/main.lua
+++ b/client/main.lua
@@ -206,7 +206,11 @@ end)
 
 RegisterNetEvent('prison:client:Enter', function(time)
 	local invokingResource = GetInvokingResource()
-	if invokingResource and invokingResource ~= 'qb-policejob' and invokingResource ~= 'qb-ambulancejob' and invokingResource ~= GetCurrentResourceName() then return end
+	if invokingResource and invokingResource ~= 'qb-policejob' and invokingResource ~= 'qb-ambulancejob' and invokingResource ~= GetCurrentResourceName() then
+		-- Use QBCore.Debug here for a quick and easy way to print to the console to grab your attention with this message
+		QBCore.Debug({('Player with source %s tried to execute prison:client:Enter manually or from another resource which is not authorized to call this, invokedResource: %s'):format(GetPlayerServerId(PlayerId()), invokingResource)})
+		return
+	end
 
 	QBCore.Functions.Notify( Lang:t("error.injail", {Time = time}), "error")
 


### PR DESCRIPTION
**Describe Pull request**
This fixes the exploit of being able to put everyone in the server into prison

GetInvokingResource() only works on a client->client and server->server event trigger, so if the event is triggered from the server it won't perform the check because the server is good to go, a cheater can't use that, but when it is triggered on the client it will check was resource it was that triggered it, if it does not match the hardcoded resources, it won't execute

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
