### PR TITLE
Fix duplication of given items when spam-leaving jail

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -351,6 +351,17 @@ CreateThread(function()
 		freedom:onPlayerInOut(function(isPointInside)
 			insidefreedom = isPointInside
 			if isPointInside then
+				CreateThread(function()
+					while insidefreedom do
+						if IsControlJustReleased(0, 38) then
+							exports['qb-core']:KeyPressed()
+							exports['qb-core']:HideText()
+							TriggerEvent("prison:client:Leave")
+							break
+						end
+						Wait(0)
+					end
+				end)
 				exports['qb-core']:DrawText('[E] Check Time', 'left')
 			else
 				exports['qb-core']:HideText()
@@ -363,32 +374,21 @@ CreateThread(function()
 		canteen:onPlayerInOut(function(isPointInside)
 			insidecanteen = isPointInside
 			if isPointInside then
+				CreateThread(function()
+					while insidecanteen do
+						if IsControlJustReleased(0, 38) then
+							exports['qb-core']:KeyPressed()
+							exports['qb-core']:HideText()
+							TriggerEvent("prison:client:canteen")
+							break
+						end
+						Wait(0)
+					end
+				end)
 				exports['qb-core']:DrawText('[E] Open Canteen', 'left')
 			else
 				exports['qb-core']:HideText()
 			end
 		end)
-		while true do
-			local sleep = 1000
-			if insidefreedom then
-				sleep = 0
-				if IsControlJustReleased(0, 38) then
-					exports['qb-core']:KeyPressed()
-					Wait(500)
-					exports['qb-core']:HideText()
-					TriggerEvent("prison:client:Leave")
-				end
-			end
-			if insidecanteen then
-				sleep = 0
-				if IsControlJustReleased(0, 38) then
-					exports['qb-core']:KeyPressed()
-					Wait(500)
-					exports['qb-core']:HideText()
-					TriggerEvent("prison:client:canteen")
-				end
-			end
-			Wait(sleep)
-		end
 	end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -33,7 +33,6 @@ RegisterNetEvent('prison:server:GiveJailItems', function(escaped)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     if not Player then return end
-    Wait(1000)
     if escaped then
         Player.Functions.SetMetaData("jailitems", {})
         return
@@ -41,7 +40,6 @@ RegisterNetEvent('prison:server:GiveJailItems', function(escaped)
     for _, v in pairs(Player.PlayerData.metadata["jailitems"]) do
         Player.Functions.AddItem(v.name, v.amount, false, v.info)
     end
-    Wait(1000)
     Player.Functions.SetMetaData("jailitems", {})
 end)
 


### PR DESCRIPTION
**Describe Pull request**
Fixes a bug where when spam-leaving the jail, the player was able to receive jail items multiple times before the `jailitems` metadata was reset to `{}`.
Optimize loops.
Fix being able to trigger leave event multiple times.

Fixes #85

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
