### PR TITLE
fix for electronickit is not used when trying to prisonbreak

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -123,3 +123,10 @@ end)
 QBCore.Functions.CreateCallback('prison:server:IsAlarmActive', function(_, cb)
     cb(AlarmActivated)
 end)
+
+QBCore.Functions.CreateUseableItem("electronickit", function(source, item)
+    local Player = QBCore.Functions.GetPlayer(source)
+    if Player.Functions.GetItemByName(item.name) then
+        TriggerClientEvent("electronickit:UseElectronickit", source)
+    end
+end)


### PR DESCRIPTION
**Describe Pull request**
Sorry if i am not following the guidelines, but this is how I fixed not being able to use electronickit item when prison breaking.
it wasn't work, at least for me.

**Questions:**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? No
- Does your code fit the style guidelines? I don't know
- Does your PR fit the contribution guidelines? I don't know
